### PR TITLE
Tweaks to play nice with connector

### DIFF
--- a/app/commands/people/create_registration.rb
+++ b/app/commands/people/create_registration.rb
@@ -54,7 +54,8 @@ module People
       @person ||= Person.new(
         first_name: form.first_name,
         last_name1: form.last_name1,
-        last_name2: form.last_name2
+        last_name2: form.last_name2,
+        document_type: form.document_type
       )
     end
 

--- a/app/models/issues/people/untrusted_phone.rb
+++ b/app/models/issues/people/untrusted_phone.rb
@@ -15,6 +15,8 @@ module Issues
 
       def blacklisted?
         phone = procedure.phone
+        return false unless phone
+
         self.class.phones_blacklist.include?(phone) || (1..phone.size - 1).any? { |i| self.class.prefixes_blacklist.include?(phone[0, i]) }
       end
 


### PR DESCRIPTION
These are a couple of tweaks I used to record census responses at https://github.com/podemos-info/decidim-module-census_connector/pull/10. No idea if they are correct (maybe the phone is indeed mandatory and we need to add it to the verification worklfow), or if this breaks anything, since I haven't yet run census' tests locally.