### PR TITLE
Fixed versions count

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -2,7 +2,6 @@
 
 class ApplicationDecorator < Draper::Decorator
   def type_name
-    # model_name = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(object.model_name.to_s))
     I18n.t("activerecord.models.#{object.class.to_s.underscore}.one")
   end
 

--- a/app/queries/versionable_count_versions.rb
+++ b/app/queries/versionable_count_versions.rb
@@ -10,10 +10,10 @@ class VersionableCountVersions < Rectify::Query
   end
 
   def query
-    @versionable.versions.where(event: "update")
+    @versionable.versions
   end
 
   def value
-    query.count + 1
+    query.count
   end
 end


### PR DESCRIPTION
I was counting only "update" versions, and adding 1 for the creation version. I guess that this was because it could not exists. Anyway, this solution was more complex and confusing in that case (there is one version, but the versions list is empty).
Fixes #125.