### PR TITLE
Fix auto acceptance of procedures

### DIFF
--- a/app/admin/procedure.rb
+++ b/app/admin/procedure.rb
@@ -40,6 +40,7 @@ ActiveAdmin.register Procedure do
     end
     column :person, class: :left, sortable: :full_name
     state_column :state
+    bool_column :auto_processed?
     column :created_at
   end
 

--- a/app/models/concerns/procedure_states.rb
+++ b/app/models/concerns/procedure_states.rb
@@ -35,6 +35,10 @@ module ProcedureStates
       accepted? || rejected?
     end
 
+    def auto_processed?
+      processed? && processed_by.nil?
+    end
+
     def undoable?
       processed_at && processed_at > Settings.procedures.undo_minutes.minutes.ago && undo_version.present?
     end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -23,7 +23,6 @@ class Procedure < ApplicationRecord
   scope :independent, -> { where depends_on: nil }
 
   validates :comment, presence: { message: I18n.t("errors.messages.procedure_denial_comment_required") }, if: :rejected?
-  validates :processed_by, presence: true, if: :processed?, unless: :auto_processed?
   validates :processed_at, presence: true, if: :processed?
   validate :processed_by, :processed_by_different_from_person
   validate :depends_on, :depends_on_person

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -23,7 +23,8 @@ class Procedure < ApplicationRecord
   scope :independent, -> { where depends_on: nil }
 
   validates :comment, presence: { message: I18n.t("errors.messages.procedure_denial_comment_required") }, if: :rejected?
-  validates :processed_by, :processed_at, presence: true, if: :processed?
+  validates :processed_by, presence: true, if: :processed?, unless: :auto_processed?
+  validates :processed_at, presence: true, if: :processed?
   validate :processed_by, :processed_by_different_from_person
   validate :depends_on, :depends_on_person
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -226,6 +226,7 @@ es:
         verification/verification_requested: verificación solicitada
         verification/verified: verificada
       procedure:
+        auto_processed?: Procesado automáticamente
         comment: Comentario
         created_at: Fecha de creación
         information: Información

--- a/spec/commands/downloads/create_download_spec.rb
+++ b/spec/commands/downloads/create_download_spec.rb
@@ -22,7 +22,7 @@ describe Downloads::CreateDownload do
     )
   end
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -48,7 +48,7 @@ describe Downloads::CreateDownload do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do

--- a/spec/commands/issues/assign_issue_spec.rb
+++ b/spec/commands/issues/assign_issue_spec.rb
@@ -8,7 +8,7 @@ describe Issues::AssignIssue do
   let!(:issue) { create(:duplicated_document) }
   let!(:admin) { create(:admin) }
 
-  describe "when is ok" do
+  context "when is ok" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end

--- a/spec/commands/issues/check_issues_spec.rb
+++ b/spec/commands/issues/check_issues_spec.rb
@@ -9,7 +9,7 @@ describe Issues::CheckIssues do
   let(:person) { build(:person) }
   let(:admin) { create(:admin) }
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :no_issues" do
       expect { subject } .to broadcast(:no_issue)
     end
@@ -19,7 +19,7 @@ describe Issues::CheckIssues do
     end
   end
 
-  describe "when another person with same document exists" do
+  context "when another person with same document exists" do
     let!(:same_person) { create(:person, :copy, from: person) }
 
     it "broadcast :new_issue" do
@@ -41,7 +41,7 @@ describe Issues::CheckIssues do
     end
   end
 
-  describe "when an unfixed issue for this document exists" do
+  context "when an unfixed issue for this document exists" do
     let!(:same_person) { create(:person, :copy, from: person) }
     let(:more_people) { create(:person, :copy, from: person) }
     before do
@@ -68,7 +68,7 @@ describe Issues::CheckIssues do
     end
   end
 
-  describe "when an unfixed issue for this document existed, but is fixed now" do
+  context "when an unfixed issue for this document existed, but is fixed now" do
     let!(:same_person) { create(:person, :copy, from: person) }
     let(:other_person) { build(:person) }
     before do

--- a/spec/commands/issues/fix_issue_spec.rb
+++ b/spec/commands/issues/fix_issue_spec.rb
@@ -13,7 +13,7 @@ describe Issues::FixIssue do
   let(:admin) { create(:admin) }
   let(:chosen_person_id) { issue.procedure.person_id }
 
-  describe "when is ok" do
+  context "when is ok" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -31,7 +31,7 @@ describe Issues::FixIssue do
     end
   end
 
-  describe "when the issue was previously assigned" do
+  context "when the issue was previously assigned" do
     before do
       issue.assigned_to = create(:person)
       issue.save!
@@ -54,7 +54,7 @@ describe Issues::FixIssue do
     end
   end
 
-  describe "when the fix information is invalid" do
+  context "when the fix information is invalid" do
     let(:chosen_person_id) { create(:person).id }
 
     it "broadcasts :invalid" do

--- a/spec/commands/issues/gone_issue_spec.rb
+++ b/spec/commands/issues/gone_issue_spec.rb
@@ -8,7 +8,7 @@ describe Issues::GoneIssue do
   let!(:issue) { create(:duplicated_document) }
   let!(:admin) { create(:admin) }
 
-  describe "when is ok" do
+  context "when is ok" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -26,7 +26,7 @@ describe Issues::GoneIssue do
     end
   end
 
-  describe "when the issue was previously assigned" do
+  context "when the issue was previously assigned" do
     before do
       issue.assigned_to = create(:person)
       issue.save!

--- a/spec/commands/issues/read_issue_spec.rb
+++ b/spec/commands/issues/read_issue_spec.rb
@@ -7,7 +7,7 @@ describe Issues::ReadIssue do
 
   let!(:issue_unread) { create(:issue_unread) }
 
-  describe "when there is an unread issue" do
+  context "when there is an unread issue" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -17,7 +17,7 @@ describe Issues::ReadIssue do
     end
   end
 
-  describe "when there is not an unread issue" do
+  context "when there is not an unread issue" do
     before do
       issue_unread.destroy
     end

--- a/spec/commands/payments/create_order_spec.rb
+++ b/spec/commands/payments/create_order_spec.rb
@@ -24,7 +24,7 @@ describe Payments::CreateOrder do
     )
   end
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok, hash_including(:order))
     end
@@ -34,7 +34,7 @@ describe Payments::CreateOrder do
     end
   end
 
-  describe "when payment method is credit card with external authentication" do
+  context "when payment method is credit card with external authentication" do
     let(:payment_method) { build(:credit_card, :external, person: order.person) }
     let(:form_class) { Orders::CreditCardExternalOrderForm }
 
@@ -47,7 +47,7 @@ describe Payments::CreateOrder do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do
@@ -59,7 +59,7 @@ describe Payments::CreateOrder do
     end
   end
 
-  describe "when payment method is inactive" do
+  context "when payment method is inactive" do
     let(:payment_method) { create(:credit_card, :expired, person: order.person) }
     let(:valid) { false }
 
@@ -72,7 +72,7 @@ describe Payments::CreateOrder do
     end
   end
 
-  describe "when payment method is an authorized credit card" do
+  context "when payment method is an authorized credit card" do
     let(:payment_method) { build(:credit_card, :external_verified, person: order.person) }
     let(:form_class) { Orders::CreditCardAuthorizedOrderForm }
 
@@ -85,7 +85,7 @@ describe Payments::CreateOrder do
     end
   end
 
-  describe "when payment method is a new direct debit" do
+  context "when payment method is a new direct debit" do
     let(:payment_method) { build(:direct_debit, person: order.person) }
     let(:form_class) { Orders::DirectDebitOrderForm }
 
@@ -99,7 +99,7 @@ describe Payments::CreateOrder do
   end
 
   context "unexpected fails scenario" do
-    describe "when payment method is invalid" do
+    context "when payment method is invalid" do
       before { stub_command("Payments::SavePaymentMethod", :invalid) }
 
       it "broadcasts :invalid" do
@@ -111,7 +111,7 @@ describe Payments::CreateOrder do
       end
     end
 
-    describe "when payment method save fails" do
+    context "when payment method save fails" do
       before { stub_command("Payments::SavePaymentMethod", :error) }
 
       it "broadcasts :error" do
@@ -123,7 +123,7 @@ describe Payments::CreateOrder do
       end
     end
 
-    describe "when order save fails" do
+    context "when order save fails" do
       before { allow_any_instance_of(Order).to receive(:save!).and_raise(ActiveRecord::Rollback) }
 
       it "broadcasts :error" do

--- a/spec/commands/payments/create_orders_batch_spec.rb
+++ b/spec/commands/payments/create_orders_batch_spec.rb
@@ -18,7 +18,7 @@ describe Payments::CreateOrdersBatch do
     )
   end
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -28,7 +28,7 @@ describe Payments::CreateOrdersBatch do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do
@@ -44,7 +44,7 @@ describe Payments::CreateOrdersBatch do
     end
   end
 
-  describe "when orders batch save fails" do
+  context "when orders batch save fails" do
     before { allow_any_instance_of(OrdersBatch).to receive(:save!).and_raise(ActiveRecord::Rollback) }
 
     it "broadcasts :error" do
@@ -56,7 +56,7 @@ describe Payments::CreateOrdersBatch do
     end
   end
 
-  describe "when order save fails" do
+  context "when order save fails" do
     before { allow_any_instance_of(Order).to receive(:save!).and_raise(ActiveRecord::Rollback) }
 
     it "broadcasts :error" do

--- a/spec/commands/payments/process_order_spec.rb
+++ b/spec/commands/payments/process_order_spec.rb
@@ -12,7 +12,7 @@ describe Payments::ProcessOrder do
   let(:order) { create(:order, :credit_card, :external_verified) }
   let(:admin) { create(:admin) }
 
-  describe "when valid" do
+  context "when valid" do
     let(:cassete) { "valid_process_order_command" }
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
@@ -28,7 +28,7 @@ describe Payments::ProcessOrder do
     end
   end
 
-  describe "when the payment fails" do
+  context "when the payment fails" do
     let(:cassete) { "failed_process_order_command" }
     let(:order) { create(:order, :credit_card) }
 
@@ -41,7 +41,7 @@ describe Payments::ProcessOrder do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:cassete) { "invalid_process_order_command" }
     let(:order) { nil }
 
@@ -50,7 +50,7 @@ describe Payments::ProcessOrder do
     end
   end
 
-  describe "when there is an error saving the payment method" do
+  context "when there is an error saving the payment method" do
     let(:cassete) { "process_order_command_save_payment_method_error" }
     before { stub_command("Payments::SavePaymentMethod", :error) }
 
@@ -69,7 +69,7 @@ describe Payments::ProcessOrder do
     end
   end
 
-  describe "when there is an error saving the order" do
+  context "when there is an error saving the order" do
     let(:cassete) { "process_order_command_save_order_error" }
     before { allow(order).to receive(:save!).and_raise(ActiveRecord::Rollback) }
 

--- a/spec/commands/payments/process_orders_batch_spec.rb
+++ b/spec/commands/payments/process_orders_batch_spec.rb
@@ -11,7 +11,7 @@ describe Payments::ProcessOrdersBatch do
   let!(:admin) { create(:admin) }
   let(:orders_batch) { create(:orders_batch) }
 
-  describe "when valid" do
+  context "when valid" do
     let(:cassete) { "valid_process_orders_batch_command" }
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
@@ -22,7 +22,7 @@ describe Payments::ProcessOrdersBatch do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:cassete) { "invalid_process_orders_batch_command" }
     let(:admin) { nil }
 
@@ -35,7 +35,7 @@ describe Payments::ProcessOrdersBatch do
     end
   end
 
-  describe "when needs review" do
+  context "when needs review" do
     let(:orders_batch) { create(:orders_batch, :with_issues) }
     let(:cassete) { "needs_review_process_orders_batch_command" }
 
@@ -48,7 +48,7 @@ describe Payments::ProcessOrdersBatch do
     end
   end
 
-  describe "when there are too many errors saving the payment methods" do
+  context "when there are too many errors saving the payment methods" do
     let(:cassete) { "process_orders_batch_command_too_many_save_payment_method_errors" }
     before { stub_command("Payments::SavePaymentMethod", :error) }
 
@@ -57,7 +57,7 @@ describe Payments::ProcessOrdersBatch do
     end
   end
 
-  describe "when there are too many errors saving the orders" do
+  context "when there are too many errors saving the orders" do
     let(:cassete) { "process_orders_batch_command_too_many_save_order_errors" }
     before { allow_any_instance_of(Order).to receive(:save!).and_raise(ActiveRecord::Rollback) }
 

--- a/spec/commands/people/create_cancellation_spec.rb
+++ b/spec/commands/people/create_cancellation_spec.rb
@@ -23,7 +23,7 @@ describe People::CreateCancellation do
   let(:channel) { "email" }
   let(:reason) { "Because yes!" }
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -46,7 +46,7 @@ describe People::CreateCancellation do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do
@@ -58,7 +58,7 @@ describe People::CreateCancellation do
     end
   end
 
-  describe "when a procedure already exists for the person" do
+  context "when a procedure already exists for the person" do
     let!(:procedure) { create(:cancellation, person: person) }
 
     it "does not create a new procedure" do

--- a/spec/commands/people/create_document_verification_spec.rb
+++ b/spec/commands/people/create_document_verification_spec.rb
@@ -21,7 +21,7 @@ describe People::CreateDocumentVerification do
 
   let(:files) { [build(:attachment).file, build(:attachment).file] }
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -31,7 +31,7 @@ describe People::CreateDocumentVerification do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do
@@ -43,7 +43,7 @@ describe People::CreateDocumentVerification do
     end
   end
 
-  describe "when a procedure already exists for the person" do
+  context "when a procedure already exists for the person" do
     let!(:procedure) { create(:document_verification, person: person) }
 
     it "does not create a new procedure" do

--- a/spec/commands/people/create_membership_level_change_spec.rb
+++ b/spec/commands/people/create_membership_level_change_spec.rb
@@ -23,7 +23,7 @@ describe People::CreateMembershipLevelChange do
 
   let(:membership_level) { "member" }
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -33,7 +33,7 @@ describe People::CreateMembershipLevelChange do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do
@@ -45,7 +45,7 @@ describe People::CreateMembershipLevelChange do
     end
   end
 
-  describe "when has no changes" do
+  context "when has no changes" do
     let(:has_changes?) { false }
 
     it "broadcasts :noop" do
@@ -57,7 +57,7 @@ describe People::CreateMembershipLevelChange do
     end
   end
 
-  describe "when a procedure already exists for the person" do
+  context "when a procedure already exists for the person" do
     let!(:procedure) { create(:membership_level_change, person: person) }
 
     it "does not create a new procedure" do

--- a/spec/commands/people/create_person_data_change_spec.rb
+++ b/spec/commands/people/create_person_data_change_spec.rb
@@ -58,7 +58,7 @@ describe People::CreatePersonDataChange do
   let(:address_scope) { nil }
   let(:document_scope) { nil }
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -81,7 +81,7 @@ describe People::CreatePersonDataChange do
     end
   end
 
-  describe "when invalid" do
+  context "when invalid" do
     let(:valid) { false }
 
     it "broadcasts :invalid" do
@@ -93,7 +93,7 @@ describe People::CreatePersonDataChange do
     end
   end
 
-  describe "when has no changes" do
+  context "when has no changes" do
     let(:has_changes?) { false }
 
     it "broadcasts :noop" do
@@ -105,7 +105,7 @@ describe People::CreatePersonDataChange do
     end
   end
 
-  describe "when a procedure already exists for the person" do
+  context "when a procedure already exists for the person" do
     let!(:procedure) { create(:person_data_change, person: person, changing_columns: [:last_name1, :email]) }
 
     it "does not create a new procedure" do

--- a/spec/commands/people/create_registration_spec.rb
+++ b/spec/commands/people/create_registration_spec.rb
@@ -59,7 +59,7 @@ describe People::CreateRegistration do
   let(:document_scope) { person.document_scope }
 
   with_versioning do
-    describe "when valid" do
+    context "when valid" do
       it "broadcasts :ok" do
         expect { subject } .to broadcast(:ok)
       end
@@ -85,7 +85,7 @@ describe People::CreateRegistration do
       end
     end
 
-    describe "when invalid" do
+    context "when invalid" do
       let(:valid) { false }
 
       it "broadcasts :invalid" do
@@ -97,7 +97,7 @@ describe People::CreateRegistration do
       end
     end
 
-    describe "when a procedure already exists for the person" do
+    context "when a procedure already exists for the person" do
       let(:existing_person) { create(:person, :pending) }
       let!(:procedure) { create(:registration, person: existing_person) }
 

--- a/spec/commands/procedures/process_procedure_spec.rb
+++ b/spec/commands/procedures/process_procedure_spec.rb
@@ -26,7 +26,7 @@ describe Procedures::ProcessProcedure do
     )
   end
 
-  describe "when valid" do
+  context "when valid" do
     it "broadcasts :ok" do
       expect { subject } .to broadcast(:ok)
     end
@@ -69,7 +69,7 @@ describe Procedures::ProcessProcedure do
     end
   end
 
-  describe "when adding an issue" do
+  context "when adding an issue" do
     let(:action) { :issue }
     it "broadcasts :issue_ok" do
       expect { subject } .to broadcast(:issue_ok)

--- a/spec/commands/procedures/undo_procedure_spec.rb
+++ b/spec/commands/procedures/undo_procedure_spec.rb
@@ -9,7 +9,7 @@ describe Procedures::UndoProcedure do
     let(:procedure) { create(:document_verification, :undoable) }
     let(:admin) { procedure.processed_by }
 
-    describe "when undoing an accepted procedure" do
+    context "when undoing an accepted procedure" do
       it "broadcasts :ok" do
         expect { subject } .to broadcast(:ok)
       end
@@ -52,7 +52,7 @@ describe Procedures::UndoProcedure do
       end
     end
 
-    describe "when undoing a rejected procedure" do
+    context "when undoing a rejected procedure" do
       let(:procedure) { create(:document_verification, :undoable_rejected) }
       it "broadcasts :ok" do
         expect { subject } .to broadcast(:ok)

--- a/spec/controllers/api/v1/payments/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/payments/orders_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::V1::Payments::OrdersController, type: :controller do
     let(:order) { build(:order) }
     let(:payment_method) { create(:direct_debit) }
 
-    describe "with an existing payment method" do
+    context "with an existing payment method" do
       let(:payment_method_params) do
         {
           payment_method_type: "existing_payment_method",

--- a/spec/controllers/orders_batches_controller_spec.rb
+++ b/spec/controllers/orders_batches_controller_spec.rb
@@ -122,7 +122,7 @@ describe OrdersBatchesController, type: :controller do
 
       it { is_expected.to be_successful }
 
-      describe "when submit pending bics" do
+      context "when submit pending bics" do
         subject(:page) { post :review_orders, params: { id: orders_batch.id, pending_bics: pending_bics } }
         let(:pending_bics) do
           Hash[orders_batch.orders.map do |order|

--- a/spec/jobs/update_procedure_job_spec.rb
+++ b/spec/jobs/update_procedure_job_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 describe UpdateProcedureJob, type: :job do
   subject(:job) { described_class.perform_now(procedure: procedure, admin: current_admin) }
 
-  let(:procedure) { create(:registration) }
   let(:current_admin) { create(:admin, :data) }
 
   context "when everything works ok" do
+    let(:procedure) { create(:registration) }
+
     it "completes the job" do
       expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
     end

--- a/spec/jobs/update_procedure_job_spec.rb
+++ b/spec/jobs/update_procedure_job_spec.rb
@@ -14,7 +14,7 @@ describe UpdateProcedureJob, type: :job do
     end
   end
 
-  describe "when a person with an open issue is cancelled" do
+  context "when a person with an open issue is cancelled" do
     let!(:open_issue) { create(:duplicated_document) }
     let(:registration_procedure) { open_issue.procedures.first }
     let(:person) { registration_procedure.person }
@@ -37,7 +37,7 @@ describe UpdateProcedureJob, type: :job do
     end
   end
 
-  describe "when a person related to an open issue is cancelled" do
+  context "when a person related to an open issue is cancelled" do
     let!(:open_issue) { create(:duplicated_document, other_person: other_person) }
     let(:registration_procedure) { open_issue.procedures.first }
     let(:person) { registration_procedure.person }

--- a/spec/jobs/update_procedure_job_spec.rb
+++ b/spec/jobs/update_procedure_job_spec.rb
@@ -5,64 +5,77 @@ require "rails_helper"
 describe UpdateProcedureJob, type: :job do
   subject(:job) { described_class.perform_now(procedure: procedure, admin: current_admin) }
 
-  let(:current_admin) { create(:admin, :data) }
+  shared_examples_for "an update procedure job" do
+    context "when everything works ok" do
+      let(:procedure) { create(:registration) }
+      let(:person) { procedure.person }
 
-  context "when everything works ok" do
-    let(:procedure) { create(:registration) }
+      it "completes the job" do
+        expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
+      end
 
-    it "completes the job" do
-      expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
+      it "accepts the new person" do
+        expect { subject }.to change { person.reload.state }.from("pending").to("enabled")
+      end
     end
 
-    it "accepts the new person" do
-      expect { subject }.to change { person.reload.state }.from("pending").to("enabled")
+    context "when a person with an open issue is cancelled" do
+      let!(:open_issue) { create(:duplicated_document) }
+      let(:registration_procedure) { open_issue.procedures.first }
+      let(:person) { registration_procedure.person }
+      let(:procedure) { create(:cancellation, person: person) }
+
+      it "completes the job" do
+        expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
+      end
+
+      it "doesn't create new issues" do
+        expect { subject } .not_to change { Issue.count }
+      end
+
+      it "closes the existing issue" do
+        expect { subject } .to change { open_issue.reload.closed_at } .from(nil)
+      end
+
+      it "keeps the issue related objects before fixing it" do
+        expect { subject } .not_to change { open_issue.reload.people }
+      end
+    end
+
+    context "when a person related to an open issue is cancelled" do
+      let!(:open_issue) { create(:duplicated_document, other_person: other_person) }
+      let(:registration_procedure) { open_issue.procedures.first }
+      let(:person) { registration_procedure.person }
+      let(:other_person) { create(:person) }
+      let(:procedure) { create(:cancellation, person: other_person) }
+
+      it "completes the job" do
+        expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
+      end
+
+      it "doesn't create new issues" do
+        expect { subject } .not_to change { Issue.count }
+      end
+
+      it "closes the existing issue" do
+        expect { subject } .to change { open_issue.reload.closed_at } .from(nil)
+      end
+
+      it "keeps the issue related objects before fixing it" do
+        expect { subject } .not_to change { open_issue.reload.people }
+      end
     end
   end
 
-  context "when a person with an open issue is cancelled" do
-    let!(:open_issue) { create(:duplicated_document) }
-    let(:registration_procedure) { open_issue.procedures.first }
-    let(:person) { registration_procedure.person }
-    let(:procedure) { create(:cancellation, person: person) }
+  context "when explicity processing" do
+    let(:current_admin) { create(:admin, :data) }
 
-    it "completes the job" do
-      expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
-    end
-
-    it "doesn't create new issues" do
-      expect { subject } .not_to change { Issue.count }
-    end
-
-    it "closes the existing issue" do
-      expect { subject } .to change { open_issue.reload.closed_at } .from(nil)
-    end
-
-    it "keeps the issue related objects before fixing it" do
-      expect { subject } .not_to change { open_issue.reload.people }
-    end
+    it_behaves_like "an update procedure job"
   end
 
-  context "when a person related to an open issue is cancelled" do
-    let!(:open_issue) { create(:duplicated_document, other_person: other_person) }
-    let(:registration_procedure) { open_issue.procedures.first }
-    let(:person) { registration_procedure.person }
-    let(:other_person) { create(:person) }
-    let(:procedure) { create(:cancellation, person: other_person) }
+  context "when auto processing" do
+    let(:current_admin) { nil }
 
-    it "completes the job" do
-      expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
-    end
-
-    it "doesn't create new issues" do
-      expect { subject } .not_to change { Issue.count }
-    end
-
-    it "closes the existing issue" do
-      expect { subject } .to change { open_issue.reload.closed_at } .from(nil)
-    end
-
-    it "keeps the issue related objects before fixing it" do
-      expect { subject } .not_to change { open_issue.reload.people }
-    end
+    it_behaves_like "an update procedure job"
   end
 end

--- a/spec/jobs/update_procedure_job_spec.rb
+++ b/spec/jobs/update_procedure_job_spec.rb
@@ -13,6 +13,10 @@ describe UpdateProcedureJob, type: :job do
     it "completes the job" do
       expect { subject } .to change { job_for(procedure)&.result } .from(nil).to("ok")
     end
+
+    it "accepts the new person" do
+      expect { subject }.to change { person.reload.state }.from("pending").to("enabled")
+    end
   end
 
   context "when a person with an open issue is cancelled" do


### PR DESCRIPTION
The census API would keep not auto-accepting user registration and returning a "pending" state for the registered users.

These changes should fix that. Specifically https://github.com/podemos-info/census/commit/b92883955f20fb9ed8e632c1d5c7301b2693ab85, the rest are mostly some minor style changes in the specs.