### PR TITLE
Include "state triplet" in show API action

### DIFF
--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -2,7 +2,8 @@
 
 class PersonSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name1, :last_name2, :document_type, :document_id, :born_at, :gender, :address,
-             :postal_code, :email, :phone, :membership_level, :scope_code, :address_scope_code, :document_scope_code
+             :postal_code, :email, :phone, :membership_level, :scope_code, :address_scope_code, :document_scope_code,
+             :state, :verification
 
   attributes Person.external_ids_attributes
 

--- a/spec/controllers/api/v1/people_controller_spec.rb
+++ b/spec/controllers/api/v1/people_controller_spec.rb
@@ -202,6 +202,18 @@ describe Api::V1::PeopleController, type: :controller do
         expect(subject["document_scope_code"]).to eq(person.document_scope.code)
       end
 
+      it "includes person state" do
+        expect(subject["state"]).to eq(person.state)
+      end
+
+      it "includes person verification" do
+        expect(subject["verification"]).to eq(person.verification)
+      end
+
+      it "includes person membership level" do
+        expect(subject["membership_level"]).to eq(person.membership_level)
+      end
+
       it "does not include hidden fields" do
         expect(subject.keys).not_to include(%w(created_at updated_at discarded_at verifications scope_id address_scope_id document_scope_id))
       end


### PR DESCRIPTION
When calling the `/api/v1/people/:person_id` endpoint, it was not returning the "state triplet" needed on the decidim side. These changes should fix that.