### PR TITLE
Create a separate staging environment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1259,6 +1259,13 @@ Rails/UniqBeforePluck:
   EnforcedStyle: conservative
   AutoCorrect: false
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test
+
 Rails/HasManyOrHasOneDependent:
   Enabled: true
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,5 +16,8 @@ test:
   <<: *default
   database: <%= ENV.fetch("DATABASE_NAME") { "census_test" } %>
 
+staging:
+  url: <%= ENV["DATABASE_URL"] %>
+
 production:
   url: <%= ENV["DATABASE_URL"] %>

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,7 +7,7 @@
 server ENV["STAGING_SERVER_MASTER_HOST"], port: ENV["STAGING_SERVER_MASTER_PORT"], user: ENV["STAGING_USER"], roles: %w(master app db web)
 server ENV["STAGING_SERVER_SLAVE_HOST"], port: ENV["STAGING_SERVER_SLAVE_PORT"], user: ENV["STAGING_USER"], roles: %w(slave app web)
 
-set :rails_env, :production
+set :rails_env, :staging
 
 # Use RVM system installation
 set :rvm_type, :system
@@ -20,10 +20,9 @@ set :sneakers_workers, %w(FinancesWorker PaymentsWorker ProceduresWorker)
 
 def db_tasks_environment
   {
-    rails_env: :production,
+    rails_env: :staging,
     disable_database_environment_check: true,
-    seed_passwords_prefix: ENV["SEED_PASSWORDS_PREFIX"],
-    seed: true
+    seed_passwords_prefix: ENV["SEED_PASSWORDS_PREFIX"]
   }
 end
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local = false
+  config.action_controller.perform_caching = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = "wss://example.com/cable"
+  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [:request_id]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "census_#{Rails.env}"
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require "syslog/logger"
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # Use sidekiq queue adapter for production
+  Rails.application.config.active_job.queue_adapter = :sneakers
+
+  raise "Please set HOST_URL environment variable before running this application on staging mode" unless Settings.security.host_url
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,7 +14,7 @@ payments:
         login: <%= ENV["REDSYS_MERCHANT_ID"] %>
         secret_key: <%= ENV["REDSYS_SECRET_KEY"] %>
         terminal: <%= ENV["REDSYS_TERMINAL"] %>
-        test: <%= !Rails.env.production? %>
+        test: <%= Rails.env.test? || Rails.env.development? %>
       response_codes:
         ok:
           flags:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,0 +1,4 @@
+payments:
+  processors:
+    redsys:
+      test: false

--- a/config/sneakers.yml
+++ b/config/sneakers.yml
@@ -12,6 +12,10 @@ development:
 test:
   <<: *default
 
+staging:
+  <<: *default
+  url: <%= ENV["SNEAKERS_URL"] %>
+
 production:
   <<: *default
   url: <%= ENV["SNEAKERS_URL"] %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ $LOAD_PATH.push base_path
 require "census/seeds/scopes"
 Census::Seeds::Scopes.seed base_path: base_path
 
-return unless ENV["SEED"]
+return if Rails.env.production?
 
 Rails.logger = Logger.new(STDOUT)
 

--- a/lib/tasks/census.rake
+++ b/lib/tasks/census.rake
@@ -6,7 +6,7 @@ namespace :db do
   desc "Reseed database without loading all scopes again"
   task :reseed, [] => :environment do
     ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
-    raise "Not allowed to run on production" if Rails.env.production? && !ENV["SEED"]
+    raise "Not allowed to run on production" if Rails.env.production?
 
     # Delete fake data
     tables = ActiveRecord::Base.connection.tables - %w(schema_migrations ar_internal_metadata)


### PR DESCRIPTION
Hei @leio10!

This PR is not meant to be merged as is, but just to open a discussion.

I run seeds on my development copy of census and I was suprised that I didn't get any test users (system0/system, and all those). The reason is that I need to set the SEED environment variable so that those actually get created. I thought that this environment variable name was a bit misleading, maybe `SEED_TEST_DATA` or something like that would be better. But then I thought that maybe the most flexible and safe solution is to actually create a separate `staging` environment, and only skip seeding test data in the production environment.

Thoughts?