### PR TITLE
Validation improvements

### DIFF
--- a/app/forms/people/person_data_form.rb
+++ b/app/forms/people/person_data_form.rb
@@ -61,7 +61,11 @@ module People
     end
 
     def document_id
-      current_document_type ? Normalizr.normalize(current_document_id, :"document_#{current_document_type}") : current_document_id
+      if current_document_type && Person.document_types.keys.include?(current_document_type)
+        Normalizr.normalize(current_document_id, :"document_#{current_document_type}")
+      else
+        current_document_id
+      end
     end
 
     private

--- a/app/forms/people/person_data_form.rb
+++ b/app/forms/people/person_data_form.rb
@@ -18,9 +18,9 @@ module People
     normalize :first_name, :last_name1, :last_name2, with: :whitespace
     normalize :address, :postal_code, with: :whitespace
 
-    validates :document_type, inclusion: { in: Person.document_types.keys }, allow_nil: true
+    validates :document_type, inclusion: { in: Person.document_types.keys }, allow_blank: true
     validates :document_id, document_id: { type: :current_document_type, scope: :current_document_scope_code }, allow_nil: true
-    validates :gender, inclusion: { in: Person.genders.keys }, allow_nil: true
+    validates :gender, inclusion: { in: Person.genders.keys }, allow_blank: true
 
     validates :first_name, :last_name1, :document_type, :document_id, :born_at, :gender, :address, :postal_code, :email, filled: { required: :complete_required? }
 

--- a/app/forms/people/person_data_form.rb
+++ b/app/forms/people/person_data_form.rb
@@ -19,7 +19,7 @@ module People
     normalize :address, :postal_code, with: :whitespace
 
     validates :document_type, inclusion: { in: Person.document_types.keys }, allow_blank: true
-    validates :document_id, document_id: { type: :current_document_type, scope: :current_document_scope_code }, allow_nil: true
+    validates :document_id, document_id: { type: :current_document_type, scope: :current_document_scope_code }, allow_blank: true
     validates :gender, inclusion: { in: Person.genders.keys }, allow_blank: true
 
     validates :first_name, :last_name1, :document_type, :document_id, :born_at, :gender, :address, :postal_code, :email, filled: { required: :complete_required? }
@@ -61,6 +61,8 @@ module People
     end
 
     def document_id
+      return current_document_id if current_document_id.blank?
+
       if current_document_type && Person.document_types.keys.include?(current_document_type)
         Normalizr.normalize(current_document_id, :"document_#{current_document_type}")
       else

--- a/app/validators/document_id_validator.rb
+++ b/app/validators/document_id_validator.rb
@@ -15,8 +15,6 @@ class DocumentIdValidator < ActiveModel::EachValidator
   end
 
   def validate_document_id(type, scope, value)
-    return false if value.nil?
-
     # Basic check for minimum length
     return false if value.length < Settings.people.document_id_minimum_length
 
@@ -27,6 +25,8 @@ class DocumentIdValidator < ActiveModel::EachValidator
   end
 
   def validate_spanish_document(type, value)
+    return false if type.blank?
+
     case type.to_sym
     when :dni
       value.upcase == value && validate_nif(value)

--- a/lib/census/normalizers/document.rb
+++ b/lib/census/normalizers/document.rb
@@ -2,20 +2,25 @@
 
 Normalizr.configure do
   add :document_dni do |value|
-    if value.present?
-      dni = value.upcase.gsub(/[\W\_]*/, "")
-      dni.rjust(dni[-1].match?(/\d/) ? 8 : 9, "0") if value.present?
+    dni = value.upcase.gsub(/[\W\_]*/, "")
+    if dni.length > 0
+      dni.rjust(dni[-1].match?(/\d/) ? 8 : 9, "0")
+    else
+      ""
     end
   end
 
   add :document_nie do |value|
-    if value.present?
-      nie = value.upcase.gsub(/[\W\_]*/, "")
-      nie[0] + nie[1..-1].rjust(nie[-1].match?(/\d/) ? 7 : 8, "0") if nie.length > 1
+    nie = value.upcase.gsub(/[\W\_]*/, "")
+
+    if nie.length > 1
+      nie[0] + nie[1..-1].rjust(nie[-1].match?(/\d/) ? 7 : 8, "0")
+    else
+      nie
     end
   end
 
   add :document_passport do |value|
-    value.upcase.gsub(/[\W\_]*/, "") if value.present?
+    value.upcase.gsub(/[\W\_]*/, "")
   end
 end

--- a/lib/census/normalizers/document.rb
+++ b/lib/census/normalizers/document.rb
@@ -3,7 +3,8 @@
 Normalizr.configure do
   add :document_dni do |value|
     dni = value.upcase.gsub(/[\W\_]*/, "")
-    if dni.length > 0
+
+    if !dni.empty?
       dni.rjust(dni[-1].match?(/\d/) ? 8 : 9, "0")
     else
       ""

--- a/spec/forms/people/person_data_change_form_spec.rb
+++ b/spec/forms/people/person_data_change_form_spec.rb
@@ -10,10 +10,18 @@ describe People::PersonDataChangeForm do
 
   it { is_expected.to be_valid }
 
-  context "when invalid gender" do
-    let(:changes) { { gender: "potato" } }
+  context "when changing gender" do
+    context "with a blank gender" do
+      let(:changes) { { gender: "" } }
 
-    it { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
+
+    context "with an invalid gender" do
+      let(:changes) { { gender: "potato" } }
+
+      it { is_expected.to be_invalid }
+    end
   end
 
   context "when changing document id" do
@@ -30,10 +38,22 @@ describe People::PersonDataChangeForm do
 
       it { is_expected.to be_invalid }
     end
+
+    context "with a blank document id" do
+      let(:changes) { { document_id: "" } }
+
+      it { is_expected.to be_invalid }
+    end
   end
 
   context "when changing document type" do
     let(:person) { create(:person, document_type: :passport, document_scope: create(:scope), document_id: "ABC1234") }
+
+    context "with a blank document type" do
+      let(:changes) { { document_type: "" } }
+
+      it { is_expected.to be_invalid }
+    end
 
     context "without setting the local scope" do
       let(:changes) { { document_type: :dni, document_id: "1R" } }

--- a/spec/forms/people/person_data_change_form_spec.rb
+++ b/spec/forms/people/person_data_change_form_spec.rb
@@ -32,7 +32,7 @@ describe People::PersonDataChangeForm do
     end
   end
 
-  context "when changing document type to dni" do
+  context "when changing document type" do
     let(:person) { create(:person, document_type: :passport, document_scope: create(:scope), document_id: "ABC1234") }
 
     context "without setting the local scope" do
@@ -43,6 +43,12 @@ describe People::PersonDataChangeForm do
 
     context "without setting a valid document id" do
       let(:changes) { { document_type: :dni, document_scope_code: "ES" } }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "without setting a valid document type" do
+      let(:changes) { { document_type: :dani, document_scope_code: "ES", document_id: "1R" } }
 
       it { is_expected.to be_invalid }
     end

--- a/spec/forms/people/registration_form_spec.rb
+++ b/spec/forms/people/registration_form_spec.rb
@@ -64,6 +64,20 @@ describe People::RegistrationForm do
     end
   end
 
+  context "with a missing document type" do
+    let(:document_type) { nil }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+
+    it "adds a single error" do
+      subject.valid?
+
+      expect(subject.errors[:document_type].count).to eq(1)
+    end
+  end
+
   context "with an empty document type" do
     let(:document_type) { "" }
 
@@ -78,6 +92,20 @@ describe People::RegistrationForm do
     end
   end
 
+  context "with a missing document id" do
+    let(:document_id) { nil }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+
+    it "adds a single error" do
+      subject.valid?
+
+      expect(subject.errors[:document_id].count).to eq(1)
+    end
+  end
+
   context "with an empty document id" do
     let(:document_id) { "" }
 
@@ -89,6 +117,20 @@ describe People::RegistrationForm do
       subject.valid?
 
       expect(subject.errors[:document_id].count).to eq(1)
+    end
+  end
+
+  context "with a missing gender" do
+    let(:gender) { nil }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+
+    it "adds a single error" do
+      subject.valid?
+
+      expect(subject.errors[:gender].count).to eq(1)
     end
   end
 

--- a/spec/forms/people/registration_form_spec.rb
+++ b/spec/forms/people/registration_form_spec.rb
@@ -56,13 +56,11 @@ describe People::RegistrationForm do
     end
   end
 
-  describe "email" do
-    context "with an empty email" do
-      let(:email) { "" }
+  context "with an empty email" do
+    let(:email) { "" }
 
-      it "is invalid" do
-        expect(subject).not_to be_valid
-      end
+    it "is invalid" do
+      expect(subject).not_to be_valid
     end
   end
 

--- a/spec/forms/people/registration_form_spec.rb
+++ b/spec/forms/people/registration_form_spec.rb
@@ -64,6 +64,48 @@ describe People::RegistrationForm do
     end
   end
 
+  context "with an empty document type" do
+    let(:document_type) { "" }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+
+    it "adds a single error" do
+      subject.valid?
+
+      expect(subject.errors[:document_type].count).to eq(1)
+    end
+  end
+
+  context "with an empty document id" do
+    let(:document_id) { "" }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+
+    it "adds a single error" do
+      subject.valid?
+
+      expect(subject.errors[:document_id].count).to eq(1)
+    end
+  end
+
+  context "with an empty gender" do
+    let(:gender) { "" }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+
+    it "adds a single error" do
+      subject.valid?
+
+      expect(subject.errors[:gender].count).to eq(1)
+    end
+  end
+
   context "when user is already registered" do
     let(:person_id) { create(:person).id }
 

--- a/spec/lib/normalizers/document_spec.rb
+++ b/spec/lib/normalizers/document_spec.rb
@@ -35,14 +35,9 @@ describe Normalizr do
       it { is_expected.to eq("00000001R") }
     end
 
-    context "handles nil values" do
-      let(:value) { nil }
-      it { is_expected.to eq(nil) }
-    end
-
     context "handles empty values" do
       let(:value) { "" }
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq("") }
     end
   end
 
@@ -74,19 +69,9 @@ describe Normalizr do
       it { is_expected.to eq("X0000001R") }
     end
 
-    context "handles nil values" do
-      let(:value) { nil }
-      it { is_expected.to eq(nil) }
-    end
-
     context "handles empty values" do
       let(:value) { "" }
-      it { is_expected.to eq(nil) }
-    end
-
-    context "returns nil on too short values" do
-      let(:value) { "" }
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq("") }
     end
   end
 
@@ -108,14 +93,9 @@ describe Normalizr do
       it { is_expected.to eq("AB1234567") }
     end
 
-    context "handles nil values" do
-      let(:value) { nil }
-      it { is_expected.to eq(nil) }
-    end
-
     context "handles empty values" do
       let(:value) { "" }
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq("") }
     end
   end
 end


### PR DESCRIPTION
To make the user experience best in the decidim side, I added these fixes to census. The idea is that blank field errors show a single error in the form, instead of showing two separate "field cannot be blank" and "field is invalid" errors. Also includes a fix for a crash when the form receives an invalid document type.

This fixes are used by [this WIP branch](https://github.com/podemos-info/decidim-module-census_connector/tree/error_handling) on the decidim-census_connector plugin.