### PR TITLE
Use codes in API errors instead of translated messages. Added extra tests

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -25,7 +25,7 @@ module Api
     def call_command(command_class, form)
       command_class.call(form: form) do
         on(:invalid) do
-          render json: form.errors, status: :unprocessable_entity
+          render json: form.errors.details, status: :unprocessable_entity
         end
         on(:error) do
           render json: {}, status: :internal_server_error

--- a/app/controllers/api/v1/payments/orders_controller.rb
+++ b/app/controllers/api/v1/payments/orders_controller.rb
@@ -6,7 +6,7 @@ module Api
       form = Orders::OrderForm.from_params(params_with_person)
       ::Payments::CreateOrder.call(form: form) do
         on(:invalid) do
-          render json: form&.errors, status: :unprocessable_entity
+          render json: form.errors.details, status: :unprocessable_entity
         end
         on(:error) do
           render json: {}, status: :internal_server_error

--- a/spec/controllers/api/v1/payments/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/payments/orders_controller_spec.rb
@@ -43,6 +43,10 @@ describe Api::V1::Payments::OrdersController, type: :controller do
           expect(subject).to have_http_status(:unprocessable_entity)
           expect(subject.content_type).to eq("application/json")
         end
+
+        it "returns the errors collection" do
+          expect(subject.body).to eq({ payment_method_id: [{ error: "inactive_payment_method" }] }.to_json)
+        end
       end
 
       context "when saving fails" do

--- a/spec/controllers/api/v1/people/document_verifications_controller_spec.rb
+++ b/spec/controllers/api/v1/people/document_verifications_controller_spec.rb
@@ -38,13 +38,15 @@ describe Api::V1::People::DocumentVerificationsController, type: :controller do
       end
 
       context "with an invalid person id" do
-        before do
-          person.delete
-        end
+        before { person.delete }
 
         it "is not valid" do
           expect(subject).to have_http_status(:unprocessable_entity)
           expect(subject.content_type).to eq("application/json")
+        end
+
+        it "returns the errors collection" do
+          expect(subject.body).to eq({ person: [{ error: "blank" }] }.to_json)
         end
       end
 

--- a/spec/controllers/api/v1/people/membership_levels_controller_spec.rb
+++ b/spec/controllers/api/v1/people/membership_levels_controller_spec.rb
@@ -40,6 +40,10 @@ describe Api::V1::People::MembershipLevelsController, type: :controller do
           expect(subject).to have_http_status(:unprocessable_entity)
           expect(subject.content_type).to eq("application/json")
         end
+
+        it "returns the errors collection" do
+          expect(subject.body).to eq({ person: [{ error: "blank" }] }.to_json)
+        end
       end
 
       context "when saving fails" do

--- a/spec/controllers/api/v1/people_controller_spec.rb
+++ b/spec/controllers/api/v1/people_controller_spec.rb
@@ -63,6 +63,10 @@ describe Api::V1::PeopleController, type: :controller do
           expect(subject).to have_http_status(:unprocessable_entity)
           expect(subject.content_type).to eq("application/json")
         end
+
+        it "returns the errors collection" do
+          expect(subject.body).to eq({ scope: [{ error: "blank" }] }.to_json)
+        end
       end
 
       context "when saving fails" do
@@ -111,6 +115,10 @@ describe Api::V1::PeopleController, type: :controller do
         it "is not valid" do
           expect(subject).to have_http_status(:unprocessable_entity)
           expect(subject.content_type).to eq("application/json")
+        end
+
+        it "returns the errors collection" do
+          expect(subject.body).to eq({ scope: [{ error: "blank" }] }.to_json)
         end
       end
 
@@ -163,6 +171,10 @@ describe Api::V1::PeopleController, type: :controller do
         it "is not valid" do
           expect(subject).to have_http_status(:unprocessable_entity)
           expect(subject.content_type).to eq("application/json")
+        end
+
+        it "returns the errors collection" do
+          expect(subject.body).to eq({ person: [{ error: "blank" }] }.to_json)
         end
       end
 


### PR DESCRIPTION
Implements #185 