### PR TITLE
Don't include unnecessary options in blank errors

### DIFF
--- a/app/validators/filled_validator.rb
+++ b/app/validators/filled_validator.rb
@@ -5,6 +5,6 @@ class FilledValidator < ActiveModel::EachValidator
     required = options.fetch(:required, true)
     required = record.send(required) if required.is_a? Symbol
 
-    record.errors.add(attribute, :blank, options) if value.blank? && (required || !value.nil?)
+    record.errors.add(attribute, :blank) if value.blank? && (required || !value.nil?)
   end
 end


### PR DESCRIPTION
Fixes a new error on #185