### PR TITLE
Better error handling

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ErrorsController < ActionController::Base
+  def not_found
+    if api_request?
+      render json: {}, status: :not_found
+    else
+      render html: "404 Not found", status: :not_found
+    end
+  end
+
+  def exception
+    if api_request?
+      render json: {}, status: :internal_server_error
+    else
+      render html: "500 Internal Server Error", status: :internal_server_error
+    end
+  end
+
+  private
+
+  def api_request?
+    request.env["ORIGINAL_FULLPATH"] =~ %r{^/api}
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,8 @@ module Census
 
     config.middleware.use Rack::Attack
 
+    config.exceptions_app = routes
+
     # Prevent host header injection (http://carlos.bueno.org/2008/06/host-header-injection.html)
     if Settings.security.host_url
       routes.default_url_options = { host: Settings.security.host_url }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,4 +52,7 @@ Rails.application.routes.draw do
       resources :orders
     end
   end
+
+  get "/404" => "errors#not_found"
+  get "/500" => "errors#exception"
 end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Errors", type: :system do
+  before(:example, environment: :production) do
+    allow(Rails.application).to receive(:env_config)
+      .with(no_args)
+      .and_wrap_original do |m, *|
+        m.call.merge("action_dispatch.show_exceptions" => true, "action_dispatch.show_detailed_exceptions" => false)
+      end
+  end
+
+  shared_examples_for "a backend url" do
+    it "returns html with a message" do
+      visit target_url
+
+      expect(page.response_headers["Content-Type"]).to match(/html/)
+      expect(page.body).to eq(error_message)
+    end
+  end
+
+  shared_examples_for "an API url" do
+    it "returns empty json" do
+      visit target_url
+
+      expect(page.response_headers["Content-Type"]).to match(/json/)
+      expect(page.body).to eq("{}")
+    end
+  end
+
+  context "when visiting a non existing url" do
+    shared_context "in the backend" do
+      let(:target_url) { "/hakuna" }
+    end
+
+    shared_context "in the API" do
+      let(:target_url) { "/api/hakuna" }
+    end
+
+    context "in development" do
+      shared_examples_for "an unexistent development url" do
+        it "returns an informative exception" do
+          expect { visit target_url }.to raise_error(ActionController::RoutingError, "No route matches [GET] \"#{target_url}\"")
+        end
+      end
+
+      context "with a backend request" do
+        include_context "in the backend"
+
+        it_behaves_like "an unexistent development url"
+      end
+
+      context "with an API request" do
+        include_context "in the API"
+
+        it_behaves_like "an unexistent development url"
+      end
+    end
+
+    context "in production", environment: :production do
+      shared_examples_for "an unexistent production url" do
+        it "returns not found status" do
+          visit target_url
+
+          expect(page).to have_http_status(:not_found)
+        end
+      end
+
+      context "with a backend request" do
+        include_context "in the backend"
+
+        it_behaves_like "an unexistent production url"
+
+        it_behaves_like "a backend url" do
+          let(:error_message) { "404 Not found" }
+        end
+      end
+
+      context "with an API request" do
+        include_context "in the API"
+
+        it_behaves_like "an unexistent production url"
+
+        it_behaves_like "an API url"
+      end
+    end
+  end
+
+  context "when server crashes" do
+    shared_context "in the backend" do
+      let(:target_url) { "/login" }
+
+      before do
+        allow_any_instance_of(Devise::SessionsController).to receive(:new, &:hakuna_matata)
+      end
+    end
+
+    shared_context "in the API" do
+      let(:person) { create(:person) }
+
+      let(:target_url) { "api/v1/people/#{person.id}@census" }
+
+      before do
+        allow_any_instance_of(Api::V1::PeopleController).to receive(:show, &:hakuna_matata)
+      end
+    end
+
+    context "in development" do
+      shared_examples_for "a crashing development url" do
+        it "crashes properly" do
+          expect { visit target_url }.to raise_error(NoMethodError, /undefined method `hakuna_matata' for/)
+        end
+      end
+
+      context "with a backend request" do
+        include_context "in the backend"
+
+        it_behaves_like "a crashing development url"
+      end
+
+      context "with an API request" do
+        include_context "in the API"
+
+        it_behaves_like "a crashing development url"
+      end
+    end
+
+    context "in production", environment: :production do
+      shared_examples_for "a crashing production url" do
+        it "crashes properly" do
+          visit target_url
+
+          expect(page).to have_http_status(:internal_server_error)
+        end
+      end
+
+      context "with a backend request" do
+        include_context "in the backend"
+
+        it_behaves_like "a crashing production url"
+
+        it_behaves_like "a backend url" do
+          let(:error_message) { "500 Internal Server Error" }
+        end
+      end
+
+      context "with an API request" do
+        include_context "in the API"
+
+        it_behaves_like "a crashing production url"
+
+        it_behaves_like "an API url"
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm playing around with the API via `curl` and I was confused because I was getting 404 errors with an empty response when trying to grab the information from a person with

```
curl -v http://mycensus:3001/api/v1/people/1
```

but 404 errors with a verbose html dump when forcing a 404 via something like

```
curl -v http://mycensus:3001/api/v1/person/1
```

Then I remembered that the endpoint needs mandatory qualified ids, but this showed that the error handling is inconsistent.

The idea of this PR is to make error handling consistent across the whole census application.