### PR TITLE
Fix random dates flaky spec failure

### DIFF
--- a/spec/factories/procedures.rb
+++ b/spec/factories/procedures.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
 
     trait :processed do
       processed_by { build(:admin) }
-      processed_at { Faker::Time.between(created_at, Settings.procedures.undo_minutes.minutes.ago, :between) }
+      processed_at { Faker::Time.between(created_at, [Settings.procedures.undo_minutes.minutes.ago, created_at].max, :between) }
       state { Faker::Boolean.boolean(0.7) ? :accepted : :rejected }
       comment { Faker::Lorem.paragraph(1, true, 2) }
     end


### PR DESCRIPTION
We just got a flaky in master: https://travis-ci.org/podemos-info/census/builds/387536482.

In some unlucky cases, it could happen that this range is incorrect
(start data before end date). So we need to make sure that doesn't
happen.