### PR TITLE
Less CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ before_deploy:
 - chmod 600 config/deploy/deploy_rsa
 - ssh-add config/deploy/deploy_rsa
 
+branches:
+  only:
+    - master
+
 deploy:
   provider: script
   script: BRANCH=$TRAVIS_BRANCH rvm $TRAVIS_RUBY_VERSION do bin/cap staging deploy


### PR DESCRIPTION
Run CI only against pushes to master and PR's. If we temporarily want to
run CI on a branch but not open a PR, we can tweak the config inside
that branch.

As you can see, this PR has a single TravisCI check.

Are you ok with this @leio10?