### PR TITLE
FIX: Allow to process procedures with closed issues

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   helper TranslationsHelper
+  helper_method :issues_for_resource
 
   before_action :set_paper_trail_whodunnit
   before_action :check_resource_issues, only: [:show, :edit]

--- a/app/views/procedures/_common_form.arb
+++ b/app/views/procedures/_common_form.arb
@@ -2,7 +2,7 @@
 
 context.instance_eval do
   if policy(procedure).update?
-    if procedure.issues.any?
+    if issues_for_resource.any?
       panel t("census.procedures.process") do
         div class: "flash flash_alert" do
           para t("census.procedures.fix_issues")


### PR DESCRIPTION
Processing form weren't be showed when a procedure has issues, even when they are all fixed.