### PR TITLE
Better locale handling

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,10 +3,12 @@
 module Api
   class ApiController < ActionController::API
     before_action :set_paper_trail_whodunnit
-    before_action :set_locale
+    around_action :switch_locale
 
-    def set_locale
-      I18n.locale = params[:locale] || I18n.default_locale
+    def switch_locale(&action)
+      locale = params[:locale] || I18n.default_locale
+
+      I18n.with_locale(locale, &action)
     end
 
     def person

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,10 +13,12 @@ class ApplicationController < ActionController::Base
 
   after_action :track_action
 
-  before_action :set_locale
+  around_action :switch_locale
 
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+
+    I18n.with_locale(locale, &action)
   end
 
   def edit; end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,12 @@ class ApplicationController < ActionController::Base
 
   after_action :track_action
 
+  before_action :set_locale
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
   def edit; end
 
   def show; end


### PR DESCRIPTION
After changing locale in API calls, admin pages start to show the UI in other languages. This PR sets the locale on every page and it does it in a thread-safe way.