### PR TITLE
Fix mailer error during seeds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    brakeman (4.6.0)
+    brakeman (4.6.1)
     builder (3.2.3)
     bunny (2.14.2)
       amq-protocol (~> 2.3, >= 2.3.0)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,8 @@ require "census/seeds/scopes"
 Census::Seeds::Scopes.new.seed base_path: "#{base_path}/scopes", logger: Rails.logger
 
 unless Rails.env.production?
+  Rails.application.config.active_job.queue_adapter = :inline
+
   require "faker"
   require "timecop"
 

--- a/db/seeds/cancellations.rb
+++ b/db/seeds/cancellations.rb
@@ -7,7 +7,7 @@ admins = Admin.where role: [:data, :data_help]
 real_now = Time.zone.now
 
 # create some cancellation procedures
-exclude_ids = (1..10).to_a + Admin.pluck(:person_id)
+exclude_ids = (1..14).to_a + Admin.pluck(:person_id)
 random_people(10, include_ids: [4], exclude_ids: exclude_ids).each do |person|
   Timecop.freeze Faker::Time.between(3.days.ago(real_now), 1.day.ago(real_now), :between)
   PaperTrail.request.whodunnit = person

--- a/db/seeds/people.rb
+++ b/db/seeds/people.rb
@@ -101,6 +101,11 @@ register_person random_person_params: { young: true }
 # 4. Canceled person (will be canceled later)
 register_person
 
+# 5 to 14. Regular adult people for tests
+10.times do
+  register_person random_person_params: { young: false }
+end
+
 Admin.roles.each_key do |role|
   2.times do |i|
     person = register_person(use_procedure: false)

--- a/db/seeds/procedures.rb
+++ b/db/seeds/procedures.rb
@@ -9,7 +9,7 @@ attachments_path = File.join(__dir__, "attachments")
 real_now = Time.zone.now
 
 # create processed document verifications
-exclude_ids = (1..10).to_a + Admin.pluck(:person_id)
+exclude_ids = (1..14).to_a + Admin.pluck(:person_id)
 random_people(5, scopes: [:enabled, :not_verified], include_ids: [2], exclude_ids: exclude_ids).each do |person|
   Timecop.freeze Faker::Time.between(person.created_at, 3.days.ago(real_now), :between)
   PaperTrail.request.whodunnit = person


### PR DESCRIPTION
Fixed used `inline` job adapter instead `async` during seeding.